### PR TITLE
Fixed blocking layer click detection

### DIFF
--- a/Packages/com.fab.uitk-runtime-dropdown/Runtime/Dropdown.cs
+++ b/Packages/com.fab.uitk-runtime-dropdown/Runtime/Dropdown.cs
@@ -488,7 +488,7 @@ namespace Fab.UITKDropdown
 
             blockingLayer.RegisterCallback<MouseDownEvent>(evt =>
             {
-                if (evt.propagationPhase == PropagationPhase.AtTarget)
+                if (evt.target == blockingLayer))
                     Close();
             });
             blockingLayer.RegisterCallback<KeyDownEvent>(evt =>


### PR DESCRIPTION
PropogationPhase.AtTarget is deprecated and this phase is no longer used, so menu's cannot be closed in newer Unity versions without selecting an item on the menu. This change fixes this problem.